### PR TITLE
TENTACLES-22: Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,6 +23,9 @@ on:
 #      - dependabot/**
   pull_request:
 
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
 jobs:
   build:
 

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -4,7 +4,7 @@
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
   <server>
-    <url>https://ge.apache.org</url>
+    <url>https://develocity.apache.org</url>
     <allowUntrusted>false</allowUntrusted>
   </server>
   <buildScan>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -3,6 +3,7 @@
 <develocity
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <projectId>creadur-tentacles</projectId>
   <server>
     <url>https://develocity.apache.org</url>
     <allowUntrusted>false</allowUntrusted>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,7 +3,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>develocity-maven-extension</artifactId>
-    <version>1.23</version>
+    <version>1.22.2</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ASF Jenkins: [![ASF Build Status](https://ci-builds.apache.org/job/Creadur/job/C
 
 GA: [![Github Action master branch status](https://github.com/apache/creadur-tentacles/actions/workflows/maven.yml/badge.svg?branch=master)](https://github.com/apache/creadur-tentacles/actions)
 
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.apache.org/scans?search.buildToolType=maven&search.rootProjectNames=Apache%20Tentacles&search.timeZoneId=Europe%2FBerlin)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://develocity.apache.org/scans?search.buildToolType=maven&search.rootProjectNames=Apache%20Tentacles&search.timeZoneId=Europe%2FBerlin)
 
 # Running with at least JDK8
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -60,6 +60,9 @@ The <action> type attribute can be add,update,fix,remove.
     </release>
     -->
     <release version="0.2-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="TENTACLES-22" type="add" dev="pottlinger" due-to="clayjohnson">
+        Integrate Creadur Tentacles into the updated develocity.apache.org instance.
+      </action>
       <action issue="TENTACLES-20" type="add" dev="pottlinger">
         Update reporting plugins and reporting configuration to work properly with doxia 2.x and new reporting plugin versions.
       </action>


### PR DESCRIPTION
This PR migrates the Tentacles project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR migrates sets a projectId for use by Develocity.

https://issues.apache.org/jira/browse/TENTACLES-22