### PR TITLE
TENTACLES-26: Try to fix possible ZIP slip attacks while consuming archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ GA: [![Github Action master branch status](https://github.com/apache/creadur-ten
 
 # Running with at least JDK 17
 
-The tool will download all the archives from a staging repo, unpack
+The tool will download all the archives from a nexus/staging repo, unpack
 them and create a little report of what is there.
 
-    java -ea -jar apache-tentacles-0.2-SNAPSHOT.jar https://repository.apache.org/content/repositories/orgapacheopenejb-090
+    java -ea -jar apache-tentacles-0.2-SNAPSHOT-jar-with-dependencies.jar https://repository.apache.org/content/repositories/orgapacheflink-1935/
+    java -ea -jar apache-tentacles-0.2-SNAPSHOT-jar-with-dependencies.jar https://repository.apache.org/content/repositories/releases/org/apache/creadur/tentacles/
 
 Assertions must be enabled.
 
-The tool is not specific to maven and will simply recursively walk
+The tool is not specific to Maven and will simply recursively walk
 the provided URL and download all files matching the following
 pattern:
 
@@ -82,7 +83,7 @@ also be unpacked.
 ## Reports
 
 The "main" report is currently called `archives.html` and will list
-all of the top-level binaries, their LICENSE and NOTICE files and any
+all the top-level binaries, their LICENSE and NOTICE files and any
 LICENSE and NOTICE files of any binaries they may contain.
 
 Validation of the output at this point is all still manual. One of

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
       <version>2.1.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
       <version>${httpClientVersion}</version>
     </dependency>
     <dependency>
@@ -94,7 +94,7 @@
     <previousTentaclesVersion>0.1</previousTentaclesVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javaVersion>17</javaVersion>
-    <httpClientVersion>4.5.14</httpClientVersion>
+    <httpClientVersion>5.6.2</httpClientVersion>
     <loggerVersion>2.26.1</loggerVersion>
     <apacheRatVersion>0.18</apacheRatVersion>
     <!-- taken from https://maven.apache.org/guides/mini/guide-reproducible-builds.html, updated by maven-release-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,15 @@
           <artifactId>sonar-maven-plugin</artifactId>
           <version>5.7.0.6970</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <forkCount>1</forkCount>
+            <!-- TENTACLES-4: We need to append to the existing arguments in order for code coverage to work -->
+            <argLine>${argLine}</argLine>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
     <project.build.outputTimestamp>2022-10-22T23:25:45Z</project.build.outputTimestamp>
     <maven.compiler.source>${javaVersion}</maven.compiler.source>
     <maven.compiler.target>${javaVersion}</maven.compiler.target>
+    <maven.compiler.release>${javaVersion}</maven.compiler.release>
   </properties>
   <distributionManagement>
     <site>
@@ -144,8 +145,6 @@
         <version>3.15.0</version>
         <configuration>
           <release>${javaVersion}</release>
-          <source>${javaVersion}</source>
-          <target>${javaVersion}</target>
         </configuration>
       </plugin>
       <plugin>
@@ -179,33 +178,6 @@
             <version>1.12.0</version>
           </dependency>
         </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.27</version>
-        <executions>
-          <execution>
-            <!-- This checks the source code of our project -->
-            <!--
-              Note that this cannot use our ${javaVersion} property, so it must
-              be changed manually when we decide to move to a higher version of
-              Java
-            -->
-            <id>check-java-1.8-compat</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <signature>
-                <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>java18</artifactId>
-                <version>1.0</version>
-              </signature>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -60,6 +60,9 @@ The <action> type attribute can be add,update,fix,remove.
     </release>
     -->
     <release version="0.2-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="TENTACLES-26" type="add" dev="pottlinger">
+        Fix possible zip slip when processing archive files.
+      </action>
       <action issue="TENTACLES-15" type="add" dev="pottlinger">
         Integrate Tentacles with SonarCloud and test coverage configuration.
       </action>

--- a/src/main/java/org/apache/creadur/tentacles/Archive.java
+++ b/src/main/java/org/apache/creadur/tentacles/Archive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  *  with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -19,7 +19,9 @@
 package org.apache.creadur.tentacles;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -46,7 +48,7 @@ public class Archive {
     private Map<URI, URI> others;
 
     public Archive(final File file, final FileSystem fileSystem,
-            final Layout layout) {
+            final Layout layout) throws IOException {
         this.fileSystem = fileSystem;
         this.layout = layout;
         this.uri =
@@ -92,14 +94,14 @@ public class Archive {
         return this.map;
     }
 
-    public Map<URI, URI> getOtherLegal() {
+    public Map<URI, URI> getOtherLegal() throws IOException {
         if (this.others == null) {
             this.others = mapOther();
         }
         return this.others;
     }
 
-    private Map<URI, URI> mapOther() {
+    private Map<URI, URI> mapOther() throws IOException {
         final File jarContents = contentsDirectory();
         final List<File> legal =
                 this.fileSystem.legalDocumentsUndeclaredIn(jarContents);
@@ -121,7 +123,7 @@ public class Archive {
         return map;
     }
 
-    private Map<URI, URI> map() {
+    private Map<URI, URI> map() throws IOException {
         final File jarContents = contentsDirectory();
         final List<File> legal =
                 this.fileSystem.legalDocumentsDeclaredIn(jarContents);
@@ -129,7 +131,7 @@ public class Archive {
         return buildMapFrom(jarContents, legal);
     }
 
-    public File contentsDirectory() {
+    public File contentsDirectory() throws IOException {
         final File archiveDocument = getFile();
         String path =
                 archiveDocument.getAbsolutePath().substring(
@@ -146,11 +148,18 @@ public class Archive {
         final File contents =
                 new File(this.layout.getContentRootDirectory(), path
                         + ".contents");
+
+        Path targetDir = this.layout.getContentRootDirectory().toPath().toAbsolutePath().normalize();
+        Path resolved = targetDir.resolve(path + ".contents").normalize();
+        if(!resolved.startsWith(targetDir)) {
+            throw new IOException("Invalid content directory: " + path + ".contents");
+        }
+
         this.fileSystem.mkdirs(contents);
         return contents;
     }
 
-    public URI contentsURI() {
+    public URI contentsURI() throws IOException {
         return contentsDirectory().toURI();
     }
 }

--- a/src/main/java/org/apache/creadur/tentacles/Configuration.java
+++ b/src/main/java/org/apache/creadur/tentacles/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/org/apache/creadur/tentacles/IOSystem.java
+++ b/src/main/java/org/apache/creadur/tentacles/IOSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/org/apache/creadur/tentacles/IOSystem.java
+++ b/src/main/java/org/apache/creadur/tentacles/IOSystem.java
@@ -106,7 +106,7 @@ public class IOSystem {
 		}
 	}
 
-	public OutputStream write(final File destination) throws IOException {
+	private OutputStream write(final File destination) throws IOException {
 		final OutputStream out = Files.newOutputStream(destination.toPath());
 		return new BufferedOutputStream(out, 32768);
 	}

--- a/src/main/java/org/apache/creadur/tentacles/IOSystem.java
+++ b/src/main/java/org/apache/creadur/tentacles/IOSystem.java
@@ -16,6 +16,7 @@
  */
 package org.apache.creadur.tentacles;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.*;
 import java.io.*;
 import java.net.URL;
@@ -71,12 +72,7 @@ public class IOSystem {
 	}
 
 	private void copy(final InputStream from, final OutputStream to) throws IOException {
-		final byte[] buffer = new byte[1024];
-		int length = 0;
-		while ((length = from.read(buffer)) != -1) {
-			to.write(buffer, 0, length);
-		}
-		to.flush();
+		IOUtils.copy(from, to);
 	}
 
 	public void copy(final byte[] from, final File to) throws IOException {

--- a/src/main/java/org/apache/creadur/tentacles/Layout.java
+++ b/src/main/java/org/apache/creadur/tentacles/Layout.java
@@ -32,13 +32,14 @@ public class Layout {
         this.localRootDirectory =
                 new File(configuration.getRootDirectoryForLocalOutput());
 
-        final FileSystem fileSystem = platform.getFileSystem();
+        final FileSystem fileSystem = platform.fileSystem();
         fileSystem.mkdirs(this.localRootDirectory);
+
+        this.output = this.localRootDirectory;
 
         this.repository = new File(this.localRootDirectory, "repo");
         this.contentRootDirectory =
                 new File(this.localRootDirectory, "content");
-        this.output = this.localRootDirectory;
 
         fileSystem.mkdirs(this.repository);
         fileSystem.mkdirs(this.contentRootDirectory);

--- a/src/main/java/org/apache/creadur/tentacles/License.java
+++ b/src/main/java/org/apache/creadur/tentacles/License.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,6 +19,7 @@
 package org.apache.creadur.tentacles;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -52,7 +53,7 @@ public class License {
         return this.locations;
     }
 
-    public Set<URI> locations(final Archive archive) {
+    public Set<URI> locations(final Archive archive) throws IOException {
         final URI contents = archive.contentsURI();
         final Set<URI> locations = new HashSet<>();
         for (final File file : this.locations) {

--- a/src/main/java/org/apache/creadur/tentacles/LicenseType.java
+++ b/src/main/java/org/apache/creadur/tentacles/LicenseType.java
@@ -31,7 +31,7 @@ public enum LicenseType {
         final Map<String, String> licenses =
                 new ConcurrentHashMap<>();
         for (final LicenseType type : values()) {
-            type.putTextInto(licenses, platform.getTentaclesResources());
+            type.putTextInto(licenses, platform.tentaclesResources());
         }
         return new Licenses(licenses, platform);
     }

--- a/src/main/java/org/apache/creadur/tentacles/Licenses.java
+++ b/src/main/java/org/apache/creadur/tentacles/Licenses.java
@@ -30,7 +30,7 @@ public class Licenses {
 
     public Licenses(final Map<String, String> licenses, final Platform platform) {
         super();
-        this.ioSystem = platform.getIoSystem();
+        this.ioSystem = platform.ioSystem();
         this.licenses = Collections.unmodifiableMap(licenses);
     }
 

--- a/src/main/java/org/apache/creadur/tentacles/Main.java
+++ b/src/main/java/org/apache/creadur/tentacles/Main.java
@@ -23,6 +23,7 @@ import static org.apache.creadur.tentacles.RepositoryType.LOCAL_FILE_SYSTEM;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -100,19 +101,17 @@ public class Main {
     		log.error("Error: Input parameter missing - you did not specify any component to run Apache Tentacles on.");
     		log.error("Please launch Apache Tentacles with an URI to work on such as 'https://repository.apache.org/content/repositories/orgapachecreadur-1000/'.");
     	} else {
-    		new Main(args).main();
+            new Main(args).run();
     	}
     	
     }
 
-    private void main() throws Exception {
-
+    private void run() throws Exception {
         unpackContents(mirrorRepositoryFrom(this.configuration));
-
         reportOn(archivesIn(this.layout.getRepositoryDirectory()));
     }
 
-    private List<Archive> archivesIn(final File repository) {
+    private List<Archive> archivesIn(final File repository) throws IOException {
         final List<File> jars = this.fileSystem.documentsFrom(repository);
 
         final List<Archive> archives = new ArrayList<>();
@@ -207,9 +206,7 @@ public class Main {
         final List<File> files = this.fileSystem.licensesDeclaredIn(contents);
 
         for (final File file : files) {
-
             undeclared.remove(this.licenses.from(file));
-
         }
 
         archive.getOtherLicenses().addAll(undeclared);
@@ -220,7 +217,6 @@ public class Main {
         archive.getDeclaredLicenses().addAll(declared);
 
         for (final License license : undeclared) {
-
             for (final License declare : declared) {
                 if (license.implies(declare)) {
                     archive.getOtherLicenses().remove(license);
@@ -233,7 +229,6 @@ public class Main {
             throws IOException {
 
         for (final Archive archive : archives) {
-
             final Set<Notice> undeclared =
                     new HashSet<>(archive.getNotices());
 
@@ -356,12 +351,18 @@ public class Main {
 
                     final String path = entry.getName();
 
-                    final File fileEntry = new File(contents, path);
+                    // check if entry has suspicious path traversal elements
+                    Path target = contents.toPath().toAbsolutePath().normalize();
+                    Path resolved = target.resolve(path).normalize();
 
+                    if(!resolved.startsWith(target)) {
+                        throw new IOException("Invalid archive entry: " + path);
+                    }
+
+                    final File fileEntry = new File(contents, path); // NOSONAR
                     this.fileSystem.mkparent(fileEntry);
 
                     // Open the output file
-
                     this.ioSystem.copy(zip, fileEntry);
 
                     if (fileEntry.getName().endsWith(".jar")) {

--- a/src/main/java/org/apache/creadur/tentacles/Main.java
+++ b/src/main/java/org/apache/creadur/tentacles/Main.java
@@ -77,9 +77,9 @@ public class Main {
         this.platform = platform;
         this.configuration = configuration;
         this.layout = layout;
-        this.fileSystem = platform.getFileSystem();
-        this.ioSystem = platform.getIoSystem();
-        this.tentaclesResources = platform.getTentaclesResources();
+        this.fileSystem = platform.fileSystem();
+        this.ioSystem = platform.ioSystem();
+        this.tentaclesResources = platform.tentaclesResources();
         this.templates = templates;
 
         this.reports = new Reports();
@@ -320,7 +320,7 @@ public class Main {
         } else if (LOCAL_FILE_SYSTEM.isRepositoryFor(configuration)) {
             final File file = new File(configuration.getStagingRepositoryURI());
             final List<File> collect =
-                    this.platform.getFileSystem().archivesInPath(file,
+                    this.platform.fileSystem().archivesInPath(file,
                             configuration.getFileRepositoryPathNameFilter());
 
             for (final File f : collect) {
@@ -349,11 +349,10 @@ public class Main {
                         continue;
                     }
 
-                    final String path = entry.getName();
-
                     // check if entry has suspicious path traversal elements
-                    Path target = contents.toPath().toAbsolutePath().normalize();
-                    Path resolved = target.resolve(path).normalize();
+                    final String path = entry.getName();
+                    final Path target = contents.toPath().toAbsolutePath().normalize();
+                    final Path resolved = target.resolve(path).normalize();
 
                     if(!resolved.startsWith(target)) {
                         throw new IOException("Invalid archive entry: " + path);

--- a/src/main/java/org/apache/creadur/tentacles/NexusClient.java
+++ b/src/main/java/org/apache/creadur/tentacles/NexusClient.java
@@ -57,8 +57,8 @@ public class NexusClient {
 
         this.client = HttpClientBuilder.create().disableContentCompression()
                 .build();
-        this.fileSystem = platform.getFileSystem();
-        this.ioSystem = platform.getIoSystem();
+        this.fileSystem = platform.fileSystem();
+        this.ioSystem = platform.ioSystem();
     }
 
     public File download(final URI uri, final File file) throws IOException {

--- a/src/main/java/org/apache/creadur/tentacles/NexusClient.java
+++ b/src/main/java/org/apache/creadur/tentacles/NexusClient.java
@@ -62,26 +62,21 @@ public class NexusClient {
     }
 
     public File download(final URI uri, final File file) throws IOException {
+        final long length = getContentLength(uri);
+
         if (file.exists()) {
-
-            final long length = getContentLength(uri);
-
             if (file.length() == length) {
-                log.info("Exists {}", uri);
+                log.info("Skipping download as file exists already: {}", uri);
                 return file;
             } else {
-                log.info("Incomplete {}", uri);
-                log.info("Download {} ({} bytes)", uri, length);
+                log.info("Incomplete - Continue downloading {} ({} bytes)", uri, length);
             }
         } else {
-            log.info("Download {}", uri);
+            log.info("Downloading {} bytes from {}", length, uri);
         }
 
-
         try (ClassicHttpResponse response = get(uri); InputStream content = response.getEntity().getContent()) {
-
             this.fileSystem.mkparent(file);
-
             this.ioSystem.copy(content, file);
         }
 
@@ -89,16 +84,15 @@ public class NexusClient {
     }
 
     private Long getContentLength(final URI uri) throws IOException {
-        final ClassicHttpResponse head = head(uri);
-        final Header[] headers = head.getHeaders(HttpHeaders.CONTENT_LENGTH);
+        try (final ClassicHttpResponse head = head(uri)) {
+            final Header[] headers = head.getHeaders(HttpHeaders.CONTENT_LENGTH);
 
-        if (headers != null && headers.length >= 1) {
-            return Long.valueOf(headers[0].getValue());
+            if (headers != null && headers.length >= 1) {
+                return Long.valueOf(headers[0].getValue());
+            }
+
+            return (long) -1;
         }
-
-        head.close();
-
-        return (long) -1;
     }
 
     private ClassicHttpResponse get(final URI uri) throws IOException {
@@ -132,49 +126,45 @@ public class NexusClient {
         log.info("Crawl {}", index);
         final Set<URI> resources = new LinkedHashSet<>();
 
-        final ClassicHttpResponse response = get(index);
+        try (final ClassicHttpResponse response = get(index);
+             final InputStream content = response.getEntity().getContent()) {
 
-        final InputStream content = response.getEntity().getContent();
-        final StreamLexer lexer = new StreamLexer(content);
+            final StreamLexer lexer = new StreamLexer(content);
+            final Set<URI> crawl = new LinkedHashSet<>();
 
-        final Set<URI> crawl = new LinkedHashSet<>();
+            // <a
+            // href="https://repository.apache.org/content/repositories/orgapacheopenejb-094/archetype-catalog.xml">archetype-catalog.xml</a>
+            while (lexer.readAndMark("<a ", "/a>")) {
+                try {
+                    final String link = lexer.peek("href=\"", "\"");
+                    final String name = lexer.peek(">", "<");
 
-        // <a
-        // href="https://repository.apache.org/content/repositories/orgapacheopenejb-094/archetype-catalog.xml">archetype-catalog.xml</a>
-        while (lexer.readAndMark("<a ", "/a>")) {
+                    final URI uri = index.resolve(link);
 
-            try {
-                final String link = lexer.peek("href=\"", "\"");
-                final String name = lexer.peek(">", "<");
+                    if (name.equals(ONE_UP)) {
+                        continue;
+                    }
+                    if (link.equals(ONE_UP)) {
+                        continue;
+                    }
 
-                final URI uri = index.resolve(link);
+                    if (name.endsWith(SLASH)) {
+                        crawl.add(uri);
+                        continue;
+                    }
 
-                if (name.equals(ONE_UP)) {
-                    continue;
+                    resources.add(uri);
+
+                } finally {
+                    lexer.unmark();
                 }
-                if (link.equals(ONE_UP)) {
-                    continue;
-                }
-
-                if (name.endsWith(SLASH)) {
-                    crawl.add(uri);
-                    continue;
-                }
-
-                resources.add(uri);
-
-            } finally {
-                lexer.unmark();
             }
+
+            for (final URI uri : crawl) {
+                resources.addAll(crawl(uri));
+            }
+
+            return resources;
         }
-
-        content.close();
-        response.close();
-
-        for (final URI uri : crawl) {
-            resources.addAll(crawl(uri));
-        }
-
-        return resources;
     }
 }

--- a/src/main/java/org/apache/creadur/tentacles/NexusClient.java
+++ b/src/main/java/org/apache/creadur/tentacles/NexusClient.java
@@ -71,10 +71,12 @@ public class NexusClient {
                 return file;
             } else {
                 log.info("Incomplete {}", uri);
+                log.info("Download {} ({} bytes)", uri, length);
             }
+        } else {
+            log.info("Download {}", uri);
         }
 
-        log.info("Download {}", uri);
 
         try (ClassicHttpResponse response = get(uri); InputStream content = response.getEntity().getContent()) {
 

--- a/src/main/java/org/apache/creadur/tentacles/NexusClient.java
+++ b/src/main/java/org/apache/creadur/tentacles/NexusClient.java
@@ -16,15 +16,17 @@
  */
 package org.apache.creadur.tentacles;
 
-import org.apache.http.Header;
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.logging.log4j.*;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import org.codehaus.swizzle.stream.StreamLexer;
 
 import java.io.File;
@@ -74,7 +76,7 @@ public class NexusClient {
 
         log.info("Download {}", uri);
 
-        try (CloseableHttpResponse response = get(uri); InputStream content = response.getEntity().getContent()) {
+        try (ClassicHttpResponse response = get(uri); InputStream content = response.getEntity().getContent()) {
 
             this.fileSystem.mkparent(file);
 
@@ -85,7 +87,7 @@ public class NexusClient {
     }
 
     private Long getContentLength(final URI uri) throws IOException {
-        final CloseableHttpResponse head = head(uri);
+        final ClassicHttpResponse head = head(uri);
         final Header[] headers = head.getHeaders(HttpHeaders.CONTENT_LENGTH);
 
         if (headers != null && headers.length >= 1) {
@@ -97,15 +99,15 @@ public class NexusClient {
         return (long) -1;
     }
 
-    private CloseableHttpResponse get(final URI uri) throws IOException {
+    private ClassicHttpResponse get(final URI uri) throws IOException {
         return get(new HttpGet(uri), this.retries);
     }
 
-    private CloseableHttpResponse head(final URI uri) throws IOException {
+    private ClassicHttpResponse head(final URI uri) throws IOException {
         return get(new HttpHead(uri), this.retries);
     }
 
-    private CloseableHttpResponse get(final HttpUriRequest request, int tries) throws IOException {
+    private ClassicHttpResponse get(final HttpUriRequest request, int tries) throws IOException {
         try {
             request.setHeader(HttpHeaders.USER_AGENT, USER_AGENT_CONTENTS);
             return this.client.execute(request);
@@ -128,7 +130,7 @@ public class NexusClient {
         log.info("Crawl {}", index);
         final Set<URI> resources = new LinkedHashSet<>();
 
-        final CloseableHttpResponse response = get(index);
+        final ClassicHttpResponse response = get(index);
 
         final InputStream content = response.getEntity().getContent();
         final StreamLexer lexer = new StreamLexer(content);

--- a/src/main/java/org/apache/creadur/tentacles/Notice.java
+++ b/src/main/java/org/apache/creadur/tentacles/Notice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,6 +19,7 @@
 package org.apache.creadur.tentacles;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -52,7 +53,7 @@ public class Notice {
         return this.locations;
     }
 
-    public Set<URI> locations(final Archive archive) {
+    public Set<URI> locations(final Archive archive) throws IOException {
         final URI contents = archive.contentsURI();
         final Set<URI> locations = new HashSet<>();
         for (final File file : this.locations) {

--- a/src/main/java/org/apache/creadur/tentacles/Platform.java
+++ b/src/main/java/org/apache/creadur/tentacles/Platform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  *  with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,7 +18,7 @@
  */
 package org.apache.creadur.tentacles;
 
-public class Platform {
+public record Platform(TentaclesResources tentaclesResources, FileSystem fileSystem, IOSystem ioSystem) {
 
     public static Platform aPlatform() {
         final FileSystem fileSystem = new FileSystem();
@@ -26,30 +26,6 @@ public class Platform {
         final TentaclesResources tentaclesResources =
                 new TentaclesResources(ioSystem);
         return new Platform(tentaclesResources, fileSystem, ioSystem);
-    }
-
-    private final TentaclesResources tentaclesResources;
-    private final FileSystem fileSystem;
-    private final IOSystem ioSystem;
-
-    public Platform(final TentaclesResources tentaclesResources,
-            final FileSystem fileSystem, final IOSystem ioSystem) {
-        super();
-        this.tentaclesResources = tentaclesResources;
-        this.fileSystem = fileSystem;
-        this.ioSystem = ioSystem;
-    }
-
-    public TentaclesResources getTentaclesResources() {
-        return this.tentaclesResources;
-    }
-
-    public FileSystem getFileSystem() {
-        return this.fileSystem;
-    }
-
-    public IOSystem getIoSystem() {
-        return this.ioSystem;
     }
 
 }

--- a/src/main/java/org/apache/creadur/tentacles/Templates.java
+++ b/src/main/java/org/apache/creadur/tentacles/Templates.java
@@ -26,8 +26,8 @@ public final class Templates {
     private final TentaclesResources tentaclesResources;
 
     public Templates(final Platform platform) {
-        this.ioSystem = platform.getIoSystem();
-        this.tentaclesResources = platform.getTentaclesResources();
+        this.ioSystem = platform.ioSystem();
+        this.tentaclesResources = platform.tentaclesResources();
         final Properties properties = new Properties();
         properties.setProperty("resource.loader.class.cache", "true");
         properties.setProperty("resource.loaders", "class");

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -23,7 +23,7 @@ Introduction to Apache Tentacles&#8482;
 
 * Running
 
- Apache Tentacles&#8482; will download all the archives from a staging repo, unpack them and create a little report of what is there.
+ Apache Tentacles&#8482; will download all the archives from a nexus/staging repo, unpack them and create a little report of what is there.
 
 +------------------------------------------+
 java -ea -jar apache-tentacles-${previousTentaclesVersion}-jar-with-dependencies.jar https://repository.apache.org/content/repositories/orgapacheopenejb-090
@@ -31,7 +31,7 @@ java -ea -jar apache-tentacles-${previousTentaclesVersion}-jar-with-dependencies
 
  Assertions must be enabled.
 
- The tool is not specific to maven and will simply recursively walk the provided URL and download all files matching the following pattern:
+ The tool is not specific to Maven and will simply recursively walk the provided URL and download all files matching the following pattern:
 
 +------------------------------------------+
 .*\.(jar|zip|war|ear|tar.gz)
@@ -98,7 +98,7 @@ content/foo.zip.contents/lib/bar.jar.contents/org/bar/Some.class
 
 * Reports
 
- The "main" report is currently called archives.html and will list all of the top-level binaires, their LICENSE and NOTICE files and any LICENSE and NOTICE files of any binaries they may contain.
+ The "main" report is currently called archives.html and will list all the top-level binaries, their LICENSE and NOTICE files and any LICENSE and NOTICE files of any binaries they may contain.
 
  Validation of the output at this point is all still manual. One of the first improvements would be to automatically flag any binaries that:
 
@@ -116,7 +116,7 @@ content/foo.zip.contents/lib/bar.jar.contents/org/bar/Some.class
 
  The Declared section lists the single LICENSE file that was supplied by the binary itself. As the tool works recursively, it will also collect any LICENSE file text from any binaries contained in the foo.zip. Well call these "sub" LICENSES for simplicity.
 
- Some attempt is made to figure out if the text from sub LICENSE files are contained in the declared LICENSE file. If the sub license text is contained in the declared LICENSE file it is not listed as Undeclared.
+ Some attempt is made to figure out if the text from sub LICENSE files are contained in the declared LICENSE file. If the sublicense text is contained in the declared LICENSE file it is not listed as Undeclared.
 
  The matching is not complete or perfect, but does help in more quickly seeing where there might be a missing LICENSE text that should be declared.
 


### PR DESCRIPTION
In the beginning I only wanted to fix the security warnings in
https://github.com/apache/creadur-tentacles/security/code-scanning

* Check for slip zip when parsing archive entries and throw IOException in case of spurious entries
* Minor refactorings in the code and streamlining of documentation (site/README)
* Properly configure to use JDK17 (similar to recent changes in RAT)